### PR TITLE
fix: Only record the playlist acquisition failure when the error is n…

### DIFF
--- a/Plugins/com.mirabox.streamdock.spotify.sdPlugin/plugin/index.js
+++ b/Plugins/com.mirabox.streamdock.spotify.sdPlugin/plugin/index.js
@@ -204,12 +204,13 @@ plugin.playpause = new Actions({
                 });
             }
         } catch (error) {
-            log.error('获取播放列表失败:', error);
             if (error.statusCode === 401) {
                 await refreshAccessToken();
                 this._propertyInspectorDidAppear({ context });
             } else if (error.code === "ECONNRESET") {
                 this._propertyInspectorDidAppear({ context });
+            } else {
+                log.error('获取播放列表失败:', error);
             }
         }
     },
@@ -1703,12 +1704,13 @@ plugin.previousornext = new Actions({
                 });
             }
         } catch (error) {
-            log.error('获取播放列表失败:', error);
             if (error.statusCode === 401) {
                 await refreshAccessToken();
                 this._propertyInspectorDidAppear({ context });
             } else if (error.code === "ECONNRESET") {
                 this._propertyInspectorDidAppear({ context });
+            } else {
+                log.error('获取播放列表失败:', error);
             }
         }
     },


### PR DESCRIPTION
…ot 401 or ECONNRESET

Modify the error handling logic to only record the playlist acquisition failure log when the error is not 401 or ECONNRESET, avoiding repeated recording of known errors.