### PR TITLE
style(propertyInspector): Modify the authorization page style and link

### DIFF
--- a/Plugins/Discord/com.mirabox.streamdock.discord.sdPlugin/propertyInspector/utils/authorization.html
+++ b/Plugins/Discord/com.mirabox.streamdock.discord.sdPlugin/propertyInspector/utils/authorization.html
@@ -66,7 +66,7 @@
         }
 
         .info2 {
-            color: red;
+            color: white;
         }
     </style>
 </head>
@@ -104,7 +104,7 @@
     })
 
     document.querySelector(".info").addEventListener('click', () => {
-        $websocket.openUrl('https://github.com/MiraboxSpace/discord-plugin-for-streamdock')
+        $websocket.openUrl('https://github.com/MiraboxSpace/StreamDock-Plugins/tree/main/Plugins/Discord')
     })
 
     // 自动翻译页面


### PR DESCRIPTION
Change the color of the .info2 class from red to white, and update the GitHub link in the click event to point to the correct repository path